### PR TITLE
fix: convert underscores in CLI name to dashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fish_manpage_completions"
+name = "fish-manpage-completions"
 version = "0.1.0"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fish_manpage_completions"
+name = "fish-manpage-completions"
 version = "0.1.0"
 authors = ["Scott Steele <scottlsteele@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
Not sure why I originally converted dashes to underscores. Don't think
there's any good reason to keep it that way.