### PR TITLE
Type1 type signature cleanup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -448,7 +448,6 @@ impl ManParser for Type1 {
 //         return True
 
 impl Type1 {
-    // TODO Type signature
     fn fallback(&self, options_section: &str) -> bool {
         unimplemented!()
     }
@@ -491,7 +490,6 @@ impl Type1 {
 //         return True
 
 impl Type1 {
-    // TODO Type signature
     fn fallback2(&self, options_section: &str) -> bool {
         unimplemented!()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,7 +492,7 @@ impl Type1 {
 
 impl Type1 {
     // TODO Type signature
-    fn fallback2(&mut self, options_section: &str) -> bool {
+    fn fallback2(&self, options_section: &str) -> bool {
         unimplemented!()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,7 +449,7 @@ impl ManParser for Type1 {
 
 impl Type1 {
     // TODO Type signature
-    fn fallback(&mut self, options_section: ()) {
+    fn fallback(&self, options_section: &str) -> bool {
         unimplemented!()
     }
 }
@@ -492,7 +492,7 @@ impl Type1 {
 
 impl Type1 {
     // TODO Type signature
-    fn fallback2(&mut self, options_section: ()) {
+    fn fallback2(&mut self, options_section: &str) -> bool {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Unsure if we should prefer `&str` vs `String` for `options_section`