### PR TITLE
Add deroff fn digit

### DIFF
--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -376,6 +376,13 @@ impl Deroffer {
         }
     }
 
+    fn digit<'a>(s: &'a str, idx: usize) -> bool {
+        match Self::str_at(s, idx) {
+            "" => false,
+            c => c.chars().all(|c| c.is_digit(10)),
+        }
+    }
+
     // Replaces the g_macro_dict lookup in the Python code
     fn g_macro_dispatch(&mut self, s: &str) -> bool {
         match s {
@@ -587,6 +594,15 @@ fn test_is_white() {
     assert_eq!(Deroffer::is_white("ab cd", 3), false);
 }
 
+#[test]
+fn test_digit() {
+    assert_eq!(Deroffer::digit("0", 0), true);
+    assert_eq!(Deroffer::digit("9", 0), true);
+    assert_eq!(Deroffer::digit("", 1), false);
+    assert_eq!(Deroffer::digit("1", 1), false);
+    assert_eq!(Deroffer::digit("a", 0), false);
+    assert_eq!(Deroffer::digit(" ", 0), false);
+}
 //     def __init__(self):
 //         self.reg_table = {}
 //         self.tr_from = ''
@@ -785,10 +801,6 @@ fn test_is_white() {
 //     def letter(self, idx):
 //         ch = self.str_at(idx)
 //         return ch.isalpha() or ch == '_' # underscore is used in C identifiers
-
-//     def digit(self, idx):
-//         ch = self.str_at(idx)
-//         return ch.isdigit()
 
 //     def number(self):
 //         match = Deroffer.g_re_number.match(self.s)


### PR DESCRIPTION
Original implementation

```py
def digit(self, idx):
     ch = self.str_at(idx)
     return ch.isdigit()
```