### PR TITLE
Pass at implementing text_arg function

### DIFF
--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -410,6 +410,30 @@ impl Deroffer {
         }
     }
 
+    fn text_arg<'a>(&mut self, s: &'a str) -> bool {
+        let mut s2 = s;
+        let mut got_something = false;
+        loop {
+            let possible = self.g_re_not_backslash_or_whitespace.find(s);
+            if let Some(m) = possible {
+                // Output the characters in the match
+                self.condputs(m.as_str());
+                s2 = self.skip_char(s2, m.end());
+                got_something = true;
+            }
+
+            if s2.is_empty() || Self::is_white(s2, 0) {
+                return got_something;
+            }
+
+            if self.esc_char(s2).is_none() {
+                self.condputs(Self::str_at(s2, 0));
+                s2 = self.skip_char(s2, 1);
+                got_something = true;
+            }
+        }
+    }
+
     // Replaces the g_macro_dict lookup in the Python code
     fn g_macro_dispatch(&mut self, s: &str) -> bool {
         match s {
@@ -574,7 +598,7 @@ impl Deroffer {
         write.flush().unwrap()
     }
 
-    fn esc_char_backslash<'a>(&self, s: &'a str) -> Option<&'a str> {
+    fn esc_char_backslash<'a>(&mut self, s: &'a str) -> Option<&'a str> {
         unimplemented!()
     }
     //     def esc_char_backslash(self):
@@ -595,7 +619,7 @@ impl Deroffer {
     //         else:
     //             return self.esc()
 
-    fn number<'a>(&self, s: &'a str) -> Option<&'a str> {
+    fn number<'a>(&mut self, s: &'a str) -> Option<&'a str> {
         unimplemented!()
     }
     //     def number(self):
@@ -607,7 +631,7 @@ impl Deroffer {
     //             self.skip_char(match.end())
     //             return True
 
-    fn word<'a>(&self, s: &'a str) -> Option<&'a str> {
+    fn word<'a>(&mut self, s: &'a str) -> Option<&'a str> {
         unimplemented!()
     }
     //     def word(self):
@@ -625,7 +649,7 @@ impl Deroffer {
     //
     //         return got_something
 
-    fn esc_char<'a>(&self, s: &'a str) -> Option<&'a str> {
+    fn esc_char<'a>(&mut self, s: &'a str) -> Option<&'a str> {
         s.get(0..1).and_then(|ch| {
             if ch == "\\" {
                 self.esc_char_backslash(s)
@@ -639,7 +663,7 @@ impl Deroffer {
         unimplemented!()
     }
 
-    fn quoted_arg<'a>(&self, string: &'a str) -> Option<&'a str> {
+    fn quoted_arg<'a>(&mut self, string: &'a str) -> Option<&'a str> {
         if Deroffer::str_at(string, 0) == "\"" {
             // We've now entered a portion of the source that should be
             // surrounded by double quotes. (We've found the first one—really


### PR DESCRIPTION
This calls `condputs` and `esc_char`, so I stubbed both of them out, although I know there's a PR open to add `esc_char`.