### PR TITLE
Add `util:translate` and `util:maketrans`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,7 @@ use std::{
 
 /// Helper for `translate`, does the same thing as string.maketrans in python
 /// requires that f and t are the same length, or it takes the shorter one
-pub fn maketrans(f: String, t: String) -> HashMap<u8, char> {
+pub fn maketrans(f: &str, t: &str) -> HashMap<u8, char> {
     HashMap::from_iter(f.bytes().zip(t.chars()))
 }
 
@@ -43,8 +43,8 @@ fn test_maketrans() {
     expected.insert(0x63, 'f');
     assert_eq!(
         maketrans(
-            "abc".to_owned(),
-            "def".to_owned(),
+            "abc",
+            "def",
         ),
         expected
     );
@@ -61,8 +61,8 @@ fn test_translate() {
         translate(
             "Hello World!".to_owned(),
             maketrans(
-                "HlW".to_owned(),
-                "aBc".to_owned(),
+                "HlW",
+                "aBc",
             )
         ),
         expected,

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,3 +7,64 @@ macro_rules! regex {
         &REGEX
     }};
 }
+
+use std::{
+    iter::FromIterator,
+    collections::HashMap,
+};
+
+
+/// Helper for `translate`, does the same thing as string.maketrans in python
+/// requires that f and t are the same length, or it takes the shorter one
+pub fn maketrans(f: String, t: String) -> HashMap<u8, char> {
+    HashMap::from_iter(f.bytes().zip(t.chars()))
+}
+
+/// Does effectively the same as string.translate in python, in 
+/// conjunction with `maketrans`, basically just replaces
+pub fn translate(s: String, table: HashMap<u8, char>) -> String {
+    let mut output = String::new();
+    for byte in s.bytes() {
+        if let Some(c) = table.get(&byte) {
+            output.push(*c);
+        } else {
+            output.push(byte as char);
+        }
+    }
+
+    output
+}
+
+#[test]
+fn test_maketrans() {
+    let mut expected = HashMap::new();
+    expected.insert(0x61, 'd');
+    expected.insert(0x62, 'e');
+    expected.insert(0x63, 'f');
+    assert_eq!(
+        maketrans(
+            "abc".to_owned(),
+            "def".to_owned(),
+        ),
+        expected
+    );
+}
+
+#[test]
+fn test_translate() {
+    // >>> "Hello World!".translate(str.maketrans("HlW", "aBc"))
+    // 'aeBBo corBd!'
+
+    let expected = "aeBBo corBd!".to_owned();
+
+    assert_eq!(
+        translate(
+            "Hello World!".to_owned(),
+            maketrans(
+                "HlW".to_owned(),
+                "aBc".to_owned(),
+            )
+        ),
+        expected,
+    )
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,31 +16,22 @@ use std::{
 
 /// Helper for `translate`, does the same thing as string.maketrans in python
 /// requires that f and t are the same length, or it takes the shorter one
-pub fn maketrans(f: &str, t: &str) -> HashMap<u8, char> {
-    HashMap::from_iter(f.bytes().zip(t.chars()))
+pub fn maketrans(f: &str, t: &str) -> HashMap<char, char> {
+    HashMap::from_iter(f.chars().zip(t.chars()))
 }
 
 /// Does effectively the same as string.translate in python, in 
 /// conjunction with `maketrans`, basically just replaces
-pub fn translate(s: String, table: HashMap<u8, char>) -> String {
-    let mut output = String::new();
-    for byte in s.bytes() {
-        if let Some(c) = table.get(&byte) {
-            output.push(*c);
-        } else {
-            output.push(byte as char);
-        }
-    }
-
-    output
+pub fn translate(s: String, table: HashMap<char, char>) -> String {
+    s.chars().map(|c| *table.get(&c).unwrap_or(&c)).collect::<String>()
 }
 
 #[test]
 fn test_maketrans() {
     let mut expected = HashMap::new();
-    expected.insert(0x61, 'd');
-    expected.insert(0x62, 'e');
-    expected.insert(0x63, 'f');
+    expected.insert('a', 'd');
+    expected.insert('b', 'e');
+    expected.insert('c', 'f');
     assert_eq!(
         maketrans(
             "abc",


### PR DESCRIPTION
These functions mirror their python counterparts, `translate` takes a String and a table (`HashMap<char, char>`) and remaps the String based on the table; and `maketrans` takes two equal length Strings and creates a table for use in the translate function.

These are needed a few times in the python source, so I made them (I couldn't find a crate for it)