### PR TITLE
reformat util:test_translationtable_new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ libflate = "*"
 
 [dev-dependencies]
 pretty_assertions = "*"
+common_macros = "*"

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,23 +34,26 @@ impl TranslationTable {
 
 #[test]
 fn test_translationtable_new() {
+    use common_macros::hash_map;
     assert!(TranslationTable::new("aaa", "Incorrect Length").is_err());
     assert!(TranslationTable::new("aaa", "bbb").is_ok());
     let tr = TranslationTable::new("ab!", "cd.").unwrap();
 
-    let mut expected = HashMap::new();
-    expected.insert('a', 'c');
-    expected.insert('b', 'd');
-    expected.insert('!', '.');
+    let expected = hash_map! {
+        'a' => 'c',
+        'b' => 'd',
+        '!' => '.',
+    };
 
     assert_eq!(tr.table, expected);
 
     // Unicode tests
     let tr = TranslationTable::new("🗻🚀🚁", "mrh").unwrap();
-    let mut expected = HashMap::new();
-    expected.insert('🗻', 'm');
-    expected.insert('🚀', 'r');
-    expected.insert('🚁', 'h');
+    let expected = hash_map! {
+        '🗻' => 'm',
+        '🚀' => 'r',
+        '🚁' => 'h',
+    };
 
     assert_eq!(tr.table, expected);
 }


### PR DESCRIPTION
Use `hash_map!` from `common_macros` to remove some HashMap initialization clutter

+ Old: 
```rust
    let mut expected = HashMap::new();
    expected.insert('a', 'c');
    expected.insert('b', 'd');
    expected.insert('!', '.');
```

+ New:
```rust
    let expected = hash_map! {
        'a' => 'c',
        'b' => 'd',
        '!' => '.',
    };
```