### PR TITLE
Tentative deroff test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +117,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +137,9 @@ version = "0.1.0"
 dependencies = [
  "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,11 +160,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -174,6 +210,51 @@ version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +263,11 @@ dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -197,12 +283,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
@@ -401,9 +509,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -426,8 +555,23 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -472,6 +616,7 @@ dependencies = [
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
@@ -482,17 +627,28 @@ dependencies = [
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
+"checksum diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+"checksum git2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cb400360e8a4d61b10e648285bbfa919bbf9519d0d5d5720354456f44349226"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum libgit2-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4c179ed6d19cd3a051e68c177fbbc214e79ac4724fac3a850ec9f3d3eb8a5578"
+"checksum libssh2-sys 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "eafa907407504b0e683786d4aba47acf250f114d37357d56608333fd167dd0fc"
+"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+"checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum lzma-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum miniz_oxide 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)" = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
@@ -515,12 +671,17 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum tinyvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vcpkg 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ xz2 = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "*"
+git2 = "*" 
+diff = "*"

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -771,10 +771,7 @@ impl Deroffer {
     }
 
     fn numreq(&mut self) -> bool {
-        // In the python, it has a check that is already handled in esc_char_backslash, which is
-        // the only place it gets called, so I'll omit that check here
-
-        if self.str_at(2) != "'" {
+        if self.str_at(2) != "'" || !"hvwud".contains(self.str_at(1)) {
             return false;
         }
 
@@ -1206,7 +1203,23 @@ fn test_font() {
 }
 
 #[test]
-fn test_numreq() {}
+fn test_numreq() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Hello World!".into();
+    assert!(!deroffer.numreq());
+    assert_eq!(deroffer.s, "Hello World!");
+    assert!(deroffer.output.take().is_empty());
+
+    deroffer.s = r"\w'Apple'".into();
+    assert!(deroffer.numreq());
+    assert!(deroffer.s.is_empty());
+    assert!(deroffer.output.take().is_empty());
+
+    deroffer.s = r"\w'Hello\tWorld!'".into();
+    assert!(deroffer.numreq());
+    assert_eq!(deroffer.s, "!'");
+    assert!(deroffer.output.take().is_empty());
+}
 
 #[test]
 fn test_size() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -53,7 +53,7 @@ pub struct Deroffer {
 impl Deroffer {
     pub fn new() -> Deroffer {
         Deroffer {
-            g_re_word: crate::regex!(r##"[a-zA-Z_]+"##),
+            g_re_word: crate::regex!(r##"^[a-zA-Z_]+"##),
             g_re_number: crate::regex!(r##"^[+-]?\d+"##),
             // sequence of not backslash or whitespace
             g_re_not_backslash_or_whitespace: crate::regex!(r##"[^ \t\n\r\f\v\\]+"##),
@@ -1268,7 +1268,24 @@ fn test_esc() {
 }
 
 #[test]
-fn test_word() {}
+fn test_word() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Hello World!".into();
+
+    assert!(deroffer.word());
+    assert_eq!(deroffer.s, " World!");
+    assert_eq!(deroffer.output.take(), "Hello");
+
+    deroffer.s = "Hello\\(ps".into();
+    assert!(deroffer.word());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello¶");
+
+    deroffer.s = "100 thousand".into();
+    assert!(!deroffer.word());
+    assert_eq!(deroffer.s, "100 thousand");
+    assert_eq!(deroffer.output.take(), "");
+}
 
 #[test]
 fn test_text() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1288,7 +1288,29 @@ fn test_word() {
 }
 
 #[test]
-fn test_text() {}
+fn test_text() {
+    let mut deroffer = Deroffer::new();
+
+    deroffer.s = "Hello World!".into();
+    assert!(deroffer.text());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello World!");
+
+    deroffer.s = "Hello\tWorld!".into();
+    assert!(deroffer.text());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello\tWorld!");
+
+    deroffer.s = "Hello\\(psWorld!".into();
+    assert!(deroffer.text());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello¶World!");
+
+    deroffer.s = "Hello 10 World!".into();
+    assert!(deroffer.text());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello 10 World!");
+}
 
 #[test]
 fn test_esc_char_backslash() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1222,7 +1222,19 @@ fn test_numreq() {
 }
 
 #[test]
-fn test_size() {}
+fn test_size() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Hello World!".into();
+    assert!(!deroffer.size());
+
+    deroffer.s = r"\s10Hello World!".into();
+    assert!(deroffer.size());
+    assert_eq!(deroffer.s, "Hello World!");
+
+    deroffer.s = r"\s-11 ignore me".into();
+    assert!(deroffer.size());
+    assert_eq!(deroffer.s, " ignore me");
+}
 
 #[test]
 fn test_esc() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1169,6 +1169,48 @@ fn deroff_files(files: &[String]) -> io::Result<()> {
 }
 
 #[test]
+fn test_text_arg() {}
+
+#[test]
+fn test_font() {}
+
+#[test]
+fn test_numreq() {}
+
+#[test]
+fn test_size() {}
+
+#[test]
+fn test_esc() {}
+
+#[test]
+fn test_word() {}
+
+#[test]
+fn test_text() {}
+
+#[test]
+fn test_esc_char_backslash() {}
+
+#[test]
+fn test_flush_output() {}
+
+#[test]
+fn test_esc_char() {}
+
+#[test]
+fn test_quoted_arg() {}
+
+#[test]
+fn test_do_line() {}
+
+#[test]
+fn test_deroff() {}
+
+#[test]
+fn test_deroff_files() {}
+
+#[test]
 fn test_do_tbl() {
     // I made this based on the python source to make sure it's doing the right things
 

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1237,7 +1237,35 @@ fn test_size() {
 }
 
 #[test]
-fn test_esc() {}
+fn test_esc() {
+    let mut deroffer = Deroffer::new();
+    assert!(!deroffer.esc());
+
+    // This is UB, but it's the same UB as the python
+    deroffer.s = "Hello World!".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "\\");
+
+    deroffer.s = r"\E".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "\\");
+    deroffer.s = r"\t".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "\t");
+
+    deroffer.s = r"\~".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), " ");
+
+    deroffer.s = r"\|".into();
+    assert!(deroffer.esc());
+    assert!(deroffer.output.take().is_empty());
+
+    deroffer.s = r"\apple".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "a");
+    assert_eq!(deroffer.s, "pple");
+}
 
 #[test]
 fn test_word() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1348,27 +1348,55 @@ fn test_esc_char_backslash() {
 
     // Taken from spec
     deroffer.s = "\\(Sdaaaa".into(); // `ð`
-    assert!(deroffer.spec());
+    assert!(deroffer.esc_char_backslash());
     assert!(deroffer.specletter);
     assert_eq!(deroffer.output.take(), "ð");
     assert_eq!(deroffer.s, "aaaa");
 
     // Taken from esc
     deroffer.s = r"\E".into();
-    assert!(deroffer.esc());
+    assert!(deroffer.esc_char_backslash());
     assert_eq!(deroffer.output.take(), "\\");
 
     // This is UB, but it's the same UB as the python
     deroffer.s = "Hello World!".into();
-    assert!(deroffer.esc());
+    assert!(deroffer.esc_char_backslash());
     assert_eq!(deroffer.output.take(), "\\");
 }
 
 #[test]
-fn test_esc_char() {}
+fn test_esc_char() {
+    // Gets passed to esc_char_backslash, stealing one test to make sure it works
+    let mut deroffer = Deroffer::new();
+    deroffer.s = r#"\"This is a comment, it will be ignored"#.into();
+    assert!(deroffer.esc_char());
+    assert!(deroffer.s.is_empty());
+
+    // Will get passed to word, stealing a test
+    deroffer.s = "Hello\\(ps".into();
+    assert!(deroffer.esc_char());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Hello¶");
+
+    // Will get passed to number, stealing a test
+    deroffer.s = String::from("4343xx7");
+    assert_eq!(deroffer.number(), true);
+    assert_eq!(deroffer.output.take(), "4343".to_string());
+}
 
 #[test]
-fn test_quoted_arg() {}
+fn test_quoted_arg() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = r#""Hello World!""#.into();
+    assert!(deroffer.quoted_arg());
+    assert_eq!(deroffer.s, "\"");
+    assert_eq!(deroffer.output.take(), "Hello World!");
+
+    deroffer.s = r#""Hello\(psWorld""#.into();
+    assert!(deroffer.quoted_arg());
+    assert_eq!(deroffer.s, "\"");
+    assert_eq!(deroffer.output.take(), "Hello¶World");
+}
 
 #[test]
 fn test_do_line() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::Read;
+use std::io::{self, Read};
 
 const SKIP_LISTS: bool = false;
 const SKIP_HEADERS: bool = false;
@@ -927,8 +927,28 @@ impl Deroffer {
         }
     }
 
-    fn spec(&self) -> bool {
-        unimplemented!()
+    fn spec(&mut self) -> bool {
+        self.specletter = false;
+
+        if self.s.get(..2) == Some("\\(") && self.not_whitespace(2) && self.not_whitespace(3) {
+            let key = self.s.get(2..4).unwrap_or_default();
+
+            if let Some(value) = Self::g_specs_specletter(key) {
+                self.condputs(value);
+                self.specletter = true;
+            } else if let Some(value) = Self::g_specs(key) {
+                self.condputs(value);
+            }
+
+            self.skip_char(4);
+            true
+        } else if self.s.starts_with("\\%") {
+            self.specletter = true;
+            self.skip_char(2);
+            true
+        } else {
+            false
+        }
     }
 
     fn esc_char_backslash(&mut self) -> bool {
@@ -947,7 +967,7 @@ impl Deroffer {
         }
     }
 
-    /// AKA `not_whitespace`
+    /// AKA `prch`
     fn not_whitespace(&self, idx: usize) -> bool {
         // # Note that this return False for the empty string (idx >= len(self.s))
         // ch = self.s[idx:idx+1]
@@ -978,10 +998,6 @@ impl Deroffer {
             }
             self.output.set(o);
         }
-    }
-
-    pub fn deroff(&mut self, string: String) {
-        unimplemented!()
     }
 
     fn flush_output<W: std::io::Write>(&mut self, mut write: W) {
@@ -1028,17 +1044,89 @@ impl Deroffer {
         }
     }
 
-    fn do_line(&self, s: &str) -> bool {
-        match s.chars().nth(0) {
-            Some('.') | Some('\'') => !request_or_macro(s),
-            Some(c) => {
+    fn do_tbl(&mut self) -> bool {
+        match self.tblstate {
+            TblState::Options => {
+                while !self.s.is_empty() && !"\n;".contains(self.str_at(0)) {
+                    self.skip_leading_whitespace();
+
+                    if !self.str_at(0).chars().all(|c| c.is_alphabetic()) {
+                        self.skip_char(1);
+                    } else {
+                        // Parse option
+
+                        // find first non-alphabetic character
+                        match self.s.char_indices().find(|(_, c)| !c.is_alphabetic()) {
+                            Some((idx, '(')) => {
+                                // self.s -> option '(' arg ')' rest
+                                let option = &self.s[..idx];
+                                let mut iter = self.s[idx + 1..].splitn(2, ')');
+                                let arg = iter.next().unwrap_or_default();
+                                let rest = iter.next().unwrap_or_default();
+
+                                if option.to_lowercase() == "tab" {
+                                    self.tblTab = arg.get(0..1).unwrap_or_default().to_owned();
+                                }
+
+                                self.s = rest.to_owned();
+                            }
+                            _ => self.s.clear(),
+                        }
+                    }
+                }
+                self.tblstate = TblState::Format;
+                self.condputs("\n");
+            }
+            TblState::Format => {
+                while !self.s.is_empty() && !".\n".contains(self.str_at(0)) {
+                    self.skip_leading_whitespace();
+                    if !self.str_at(0).is_empty() {
+                        self.skip_char(1);
+                    }
+                }
+
+                if self.str_at(0) == "." {
+                    self.tblstate = TblState::Data;
+                }
+                self.condputs("\n");
+            }
+            TblState::Data => {
+                if !self.tblTab.is_empty() {
+                    self.s = self.s.replace(&self.tblTab, "\n");
+                }
+
+                self.text();
+            }
+        }
+
+        true
+    }
+
+    fn do_line(&mut self) -> bool {
+        match self
+            .s
+            .bytes()
+            .next()
+            .expect("`do_line` called when `self.s` was empty")
+        {
+            b'.' | b'\'' => !self.request_or_macro(),
+            _ => {
                 if self.tbl {
-                    do_tbl(s)
+                    self.do_tbl()
                 } else {
-                    text(s)
+                    self.text()
                 }
             }
-            None => panic!("do_line` called with empty string as argument"),
+        }
+    }
+
+    pub fn deroff(&mut self, s: String) {
+        let lines = s.split('\n');
+        for line in lines {
+            self.s = line.to_owned() + "\n";
+            if !self.do_line() {
+                break;
+            }
         }
     }
 }
@@ -1060,10 +1148,9 @@ fn test_comment() {
     assert_eq!(deroffer.s, "\nworld".to_owned());
 }
 
-fn deroff_files(files: &[String]) -> std::io::Result<()> {
+fn deroff_files(files: &[String]) -> io::Result<()> {
     for arg in files {
-        eprintln!("processing deroff file: {}", arg);
-
+        eprintln!("{}", arg);
         let mut file = File::open(arg)?;
         let mut string = String::new();
         if arg.ends_with(".gz") {
@@ -1072,13 +1159,114 @@ fn deroff_files(files: &[String]) -> std::io::Result<()> {
         } else {
             file.read_to_string(&mut string)?;
         }
-        let mut d = Deroffer::new();
-        println!("string: {}", string);
 
-        d.deroff(string);
-        d.flush_output(std::io::stdout());
+        let mut deroffer = Deroffer::new();
+        deroffer.deroff(string);
+        deroffer.flush_output(io::stdout());
     }
+
     Ok(())
+}
+
+#[test]
+fn test_do_tbl() {
+    // I made this based on the python source to make sure it's doing the right things
+
+    // <Options>
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+
+    deroffer.s = "aaa(bbb);Hello World!".into();
+    assert!(deroffer.do_tbl());
+    assert!(deroffer.tblTab.is_empty());
+    assert_eq!(deroffer.s, ";Hello World!");
+    assert_eq!(deroffer.output.take(), "\n");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+    deroffer.s = "aaa(bbb;Hello World!".into();
+    assert!(deroffer.do_tbl());
+    assert!(deroffer.tblTab.is_empty());
+    assert!(deroffer.s.is_empty());
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+    deroffer.s = ";".into();
+    assert!(deroffer.do_tbl());
+    assert!(deroffer.tblTab.is_empty());
+    assert_eq!(deroffer.s, ";");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+    deroffer.s = "\n".into();
+    assert!(deroffer.do_tbl());
+    assert!(deroffer.tblTab.is_empty());
+    assert_eq!(deroffer.s, "\n");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+    assert!(deroffer.do_tbl());
+    assert!(deroffer.tblTab.is_empty());
+    assert!(deroffer.s.is_empty());
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Options;
+    deroffer.s = "Tab(arg);".into();
+    assert!(deroffer.do_tbl());
+    assert_eq!(deroffer.tblTab, "a");
+    assert_eq!(deroffer.s, ";");
+
+    // </Options>
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Format;
+
+    deroffer.s = "".into();
+
+    let mut deroffer = Deroffer::new();
+    deroffer.tblstate = TblState::Data;
+
+    deroffer.s = "".into();
+}
+
+#[test]
+fn test_spec() {
+    // I create new deroffers for each test to reset the shared state
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "\\(Sdaaaa".into(); // `ð`
+    assert!(deroffer.spec());
+    assert!(deroffer.specletter);
+    assert_eq!(deroffer.output.take(), "ð");
+    assert_eq!(deroffer.s, "aaaa");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "\\(miaaaa".into(); // `-`
+    assert!(deroffer.spec());
+    assert!(!deroffer.specletter);
+    assert_eq!(deroffer.output.take(), "-");
+    assert_eq!(deroffer.s, "aaaa");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "\\(aaaaaa".into();
+    assert!(deroffer.spec());
+    assert!(!deroffer.specletter);
+    assert!(deroffer.output.take().is_empty());
+    assert_eq!(deroffer.s, "aaaa");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "\\%asdasdasd".into();
+    assert!(deroffer.spec());
+    assert!(deroffer.specletter);
+    assert!(deroffer.output.take().is_empty());
+    assert_eq!(deroffer.s, "asdasdasd");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Hello World!".into();
+    assert!(!deroffer.spec());
+    assert_eq!(deroffer.s, "Hello World!");
+    assert!(deroffer.output.take().is_empty());
 }
 
 #[test]
@@ -1313,102 +1501,6 @@ fn test_number() {
     d.s = String::from("+078t");
     assert_eq!(d.number(), true);
 }
-
-//     def spec(self):
-//         self.specletter = False
-//         if self.s[0:2] == '\\(' and self.not_whitespace(2) and self.not_whitespace(3):
-//             key = self.s[2:4]
-//             if key in Deroffer.g_specs_specletter:
-//                 self.condputs(Deroffer.g_specs_specletter[key])
-//                 self.specletter = True
-//             elif key in Deroffer.g_specs:
-//                 self.condputs(Deroffer.g_specs[key])
-//             self.skip_char(4)
-//             return True
-//         elif self.s.startswith('\\%'):
-//             self.specletter = True
-//             self.skip_char(2)
-//             return True
-//         else:
-//             return False
-
-fn text(s: &str) -> bool {
-    unimplemented!()
-}
-
-fn request_or_macro(s: &str) -> bool {
-    unimplemented!()
-}
-
-fn do_tbl(s: &str) -> bool {
-    unimplemented!()
-}
-//     def do_tbl(self):
-//         if self.tblstate == self.OPTIONS:
-//             while self.s and self.str_at(0) != ';' and self.str_at(0) != '\n':
-//                 self.skip_leading_whitespace()
-//                 if not self.str_at(0).isalpha():
-//                     # deroff.c has a bug where it can loop forever here...we try to work around it
-//                     self.skip_char()
-//                 else: # Parse option
-//
-//                     option = self.s
-//                     arg = ''
-//
-//                     idx = 0
-//                     while option[idx:idx+1].isalpha():
-//                         idx += 1
-//
-//                     if option[idx:idx+1] == '(':
-//                         option = option[:idx]
-//                         self.s = self.s[idx+1:]
-//                         arg = self.s
-//                     else:
-//                         self.s = ''
-//
-//                     if arg:
-//                         idx = arg.find(')')
-//                         if idx != -1:
-//                             arg = arg[:idx]
-//                         self.s = self.s[idx+1:]
-//                     else:
-//                         #self.skip_char()
-//                         pass
-//
-//                     if option.lower() == 'tab':
-//                         self.tblTab = arg[0:1]
-//
-//             self.tblstate = self.FORMAT
-//             self.condputs('\n')
-//
-//         elif self.tblstate == self.FORMAT:
-//             while self.s and self.str_at(0) != '.' and self.str_at(0) != '\n':
-//                 self.skip_leading_whitespace()
-//                 if self.str_at(0): self.skip_char()
-//
-//             if self.str_at(0) == '.': self.tblstate = self.DATA
-//             self.condputs('\n')
-//         elif self.tblstate == self.DATA:
-//             if self.tblTab:
-//                 self.s = self.s.replace(self.tblTab, '\t')
-//             self.text()
-//         return True
-
-//     def do_line(self):
-//         if self.s[0:1] in ".'":
-//             if not self.request_or_macro(): return False
-//         elif self.tbl:
-//             self.do_tbl()
-//         else:
-//             self.text()
-//         return True
-
-//     def deroff(self, str):
-//         lines = str.split('\n')
-//         for line in lines:
-//             self.s = line + '\n'
-//             if not self.do_line():
-//                 break
 
 // if __name__ == "__main__":
 //     import gzip

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -708,7 +708,6 @@ impl Deroffer {
         let s0 = self.s.chars().nth(1).unwrap_or('_'); // _ will be ignored by the match
 
         match s0 {
-            // There was a condition here for `\\`, but it required that s0 was also `"`, so the code was unreachable, I removed it, and I will remove this commment once people see it, just ping me or something.
             '[' => {
                 self.refer = true;
                 self.condputs("\n");

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -766,7 +766,7 @@ impl Deroffer {
     }
 
     fn numreq(&mut self) -> bool {
-        if self.str_at(2) != "'" || !"hvwud".contains(self.str_at(1)) {
+        if !"hvwud".contains(self.str_at(1)) || self.str_at(2) != "'" {
             return false;
         }
 

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1365,9 +1365,6 @@ fn test_esc_char_backslash() {
 }
 
 #[test]
-fn test_flush_output() {}
-
-#[test]
 fn test_esc_char() {}
 
 #[test]

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1313,7 +1313,56 @@ fn test_text() {
 }
 
 #[test]
-fn test_esc_char_backslash() {}
+fn test_esc_char_backslash() {
+    let mut deroffer = Deroffer::new();
+
+    deroffer.s = r#"\"This is a comment, it will be ignored"#.into();
+    assert!(deroffer.esc_char_backslash());
+    assert!(deroffer.s.is_empty());
+
+    // This gets passed to `font`, so i stole a test from there
+    deroffer.s = r"\f(aa)lemon".into();
+    assert!(deroffer.esc_char_backslash());
+    assert_eq!(deroffer.s, ")lemon");
+
+    // This gets passed to `size`
+    deroffer.s = r"\s-11 ignore me".into();
+    assert!(deroffer.esc_char_backslash());
+    assert_eq!(deroffer.s, " ignore me");
+
+    // You get the idea
+    // Taken from numreq
+    deroffer.s = r"\w'Apple'".into();
+    assert!(deroffer.esc_char_backslash());
+    assert!(deroffer.s.is_empty());
+    assert!(deroffer.output.take().is_empty());
+
+    // Taken from var
+    deroffer.s = "\\*[test_reg]".to_owned();
+    deroffer
+        .reg_table
+        .insert("test_reg".to_owned(), "It me!".to_owned());
+    assert!(deroffer.esc_char_backslash());
+    assert_eq!(deroffer.s, " me!");
+    assert!(deroffer.output.take().contains("It"));
+
+    // Taken from spec
+    deroffer.s = "\\(Sdaaaa".into(); // `ð`
+    assert!(deroffer.spec());
+    assert!(deroffer.specletter);
+    assert_eq!(deroffer.output.take(), "ð");
+    assert_eq!(deroffer.s, "aaaa");
+
+    // Taken from esc
+    deroffer.s = r"\E".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "\\");
+
+    // This is UB, but it's the same UB as the python
+    deroffer.s = "Hello World!".into();
+    assert!(deroffer.esc());
+    assert_eq!(deroffer.output.take(), "\\");
+}
 
 #[test]
 fn test_flush_output() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -13,6 +13,7 @@ use std::io::{self, Read};
 const SKIP_LISTS: bool = false;
 const SKIP_HEADERS: bool = false;
 
+#[derive(PartialEq, Debug, Clone, Copy)]
 enum TblState {
     Options,
     Format,

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -774,11 +774,6 @@ impl Deroffer {
         // In the python, it has a check that is already handled in esc_char_backslash, which is
         // the only place it gets called, so I'll omit that check here
 
-        // This is written as `self.macro += 1` in the source, but I dont know why
-        // it does the same thing (false -> true, true -> still true) :shrug:
-        // self.r#macro = true;
-        // Upon further investigation, this is the weirdest function ever
-        // This is just a state placeholder thing
         if self.str_at(2) != "'" {
             return false;
         }
@@ -1201,7 +1196,14 @@ fn test_text_arg() {
 }
 
 #[test]
-fn test_font() {}
+fn test_font() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = r"\f(aa)lemon".into();
+    assert!(deroffer.font());
+    assert_eq!(deroffer.s, ")lemon");
+    assert!(!deroffer.font());
+    assert_eq!(deroffer.s, ")lemon");
+}
 
 #[test]
 fn test_numreq() {}

--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -1169,7 +1169,36 @@ fn deroff_files(files: &[String]) -> io::Result<()> {
 }
 
 #[test]
-fn test_text_arg() {}
+fn test_text_arg() {
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Hello World!".into();
+    assert!(deroffer.text_arg());
+    assert_eq!(deroffer.s, " World!");
+    assert_eq!(deroffer.output.take(), "Hello");
+
+    let mut deroffer = Deroffer::new();
+    assert!(!deroffer.text_arg());
+    assert!(deroffer.s.is_empty());
+    assert!(deroffer.output.take().is_empty());
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "\t\n\t           \t\n".into();
+    assert!(!deroffer.text_arg());
+    assert_eq!(deroffer.s, "\t\n\t           \t\n");
+    assert!(deroffer.output.take().is_empty());
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = r"\r".into();
+    assert!(deroffer.text_arg());
+    assert!(deroffer.s.is_empty());
+    assert_eq!(deroffer.output.take(), "r");
+
+    let mut deroffer = Deroffer::new();
+    deroffer.s = "Applebees".into();
+    assert!(deroffer.text_arg());
+    assert_eq!(deroffer.s, "");
+    assert_eq!(deroffer.output.take(), "Applebees");
+}
 
 #[test]
 fn test_font() {}


### PR DESCRIPTION
There are still a lot of failures, need to figure out why. Currently the test outputs the `get_output()` result of the deroffer to `./test_deroff_output/<manpage_name>.deroffed`, but only if the deroffed was different from the deroffed from the python. It also clones the `manpages` repo (so we have a consistent test suite). There are lots of bugs, somebody please help me find them :sob:
It looks like the majority of the failures are due to the `.de` macro, or `.nr`, but please investigate, i've run out of brain to diag 


🦀 