### PR TITLE
fix(drain): panic when different length

### DIFF
--- a/src/deroff.rs
+++ b/src/deroff.rs
@@ -358,7 +358,15 @@ impl Deroffer {
     }
 
     fn skip_char(&mut self, amount: usize) {
-        self.s.drain(0..amount);
+        // drain takes in byte position but amount is character position
+        match self.s.char_indices().nth(amount) {
+            Some((pos, _)) => {
+                self.s.drain(..pos);
+            }
+            None => {
+                self.s.clear();
+            }
+        }
     }
 
     fn skip_leading_whitespace(&mut self) {
@@ -1768,14 +1776,18 @@ fn test_digit() {
 #[test]
 fn test_skip_char() {
     let mut d = Deroffer::new();
-    d.s = String::from("      Hello         World");
+    d.s = String::from("      Hello         World一");
     d.skip_char(6);
-    assert_eq!(&d.s, "Hello         World");
+    assert_eq!(&d.s, "Hello         World一");
     d.skip_char(5);
-    assert_eq!(&d.s, "         World");
+    assert_eq!(&d.s, "         World一");
     d.skip_char(9);
-    assert_eq!(&d.s, "World");
+    assert_eq!(&d.s, "World一");
     d.skip_char(5);
+    assert_eq!(&d.s, "一");
+    d.skip_char(1);
+    assert_eq!(&d.s, "");
+    d.skip_char(1);
     assert_eq!(&d.s, "");
 }
 


### PR DESCRIPTION
Python slice behavior works even when the end length is not achieved
but just the output length will be shorter but rust length requires it
to hit exactly that length and when the length is not enough or within
a boundary, it will panic. So we have to count by character boundary
and at the same time prevent the characters length from overflowing.

I hit some panics when running it through my system files when I wanted to test out the progress bar (done but still testing).