### PR TITLE
feat: add basic progress bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,10 +198,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
+name = "crossbeam-channel"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -238,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "fish-manpage-completions"
 version = "0.1.0"
 dependencies = [
@@ -245,9 +298,11 @@ dependencies = [
  "bzip2",
  "dirs",
  "flate2",
+ "indicatif",
  "itertools",
  "lazy_static",
  "pretty_assertions",
+ "rayon",
  "regex",
  "structopt",
  "tracing",
@@ -307,6 +362,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "rayon",
+ "regex",
 ]
 
 [[package]]
@@ -385,6 +453,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +489,22 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "output_vt100"
@@ -486,6 +579,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -567,6 +685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"
@@ -667,6 +791,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ xz2 = "0.1.6"
 dirs = "3.0.1"
 tracing = "0.1.22"
 tracing-subscriber = "0.2.15"
+indicatif = { version = "0.16.2", features = ["rayon"] }
+rayon = "1.5.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,9 @@ use std::{env, fmt};
 
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
+use indicatif::ParallelProgressIterator;
 use itertools::Itertools;
+use rayon::prelude::*;
 use structopt::StructOpt;
 use tracing_subscriber::filter::LevelFilter;
 use xz2::read::XzDecoder;
@@ -1317,18 +1319,18 @@ fn parse_manpage_at_path(
 }
 
 /// Get the number of digits in num
-fn num_digits(n: usize) -> usize {
-    (1.max(n) as f32).log10() as usize + 1
-}
+// fn num_digits(n: usize) -> usize {
+//     (1.max(n) as f32).log10() as usize + 1
+// }
 
-#[test]
-fn test_num_digits() {
-    assert_eq!(num_digits(1000), 4);
-    assert_eq!(num_digits(100), 3);
-    assert_eq!(num_digits(33), 2);
-    assert_eq!(num_digits(123456789012345), 15);
-    assert_eq!(num_digits(0), 1);
-}
+// #[test]
+// fn test_num_digits() {
+//     assert_eq!(num_digits(1000), 4);
+//     assert_eq!(num_digits(100), 3);
+//     assert_eq!(num_digits(33), 2);
+//     assert_eq!(num_digits(123456789012345), 15);
+//     assert_eq!(num_digits(0), 1);
+// }
 
 fn parse_and_output_man_pages(
     paths: &mut [PathBuf],
@@ -1338,58 +1340,68 @@ fn parse_and_output_man_pages(
 ) {
     paths.sort();
 
-    let total = paths.len();
+    // let max_digits = num_digits(paths.len());
+    // let (tx, rx) = mpsc::channel::<PathBuf>();
 
-    let mut successful_count = 0;
-    let max_digits = num_digits(total);
+    // // XXX: maybe we can do custom drawing logic or paint ourselves?
+    // if let Some(output_directory) = output_directory.as_ref() {
+    //     if show_progress {
+    //         println!(
+    //             "Parsing man pages and writing completions to {}",
+    //             output_directory.display()
+    //         );
 
-    if let Some(output_directory) = output_directory.as_ref() {
-        if show_progress {
-            println!(
-                "Parsing man pages and writing completions to {}",
-                output_directory.display()
-            );
-        }
-    }
+    //         // draw in another thread
+    //         thread::spawn(move || {
+    //             let mut index = 1;
+    //             while let Ok(manpage_path) = rx.recv() {
+    //                 // foo/bar/gcc.1.gz -> gcc.1.gz
+    //                 let man_file_name = manpage_path
+    //                     .file_name()
+    //                     .map(|fname| fname.to_string_lossy())
+    //                     .unwrap_or_else(|| {
+    //                         panic!(
+    //                             "Failed to get manfile name from {:?}",
+    //                             manpage_path.display()
+    //                         )
+    //                     });
 
-    for (index, manpage_path) in paths.iter().enumerate() {
-        // foo/bar/gcc.1.gz -> gcc.1.gz
-        let man_file_name = manpage_path
-            .file_name()
-            .map(|fname| fname.to_string_lossy())
-            .unwrap_or_else(|| {
-                panic!(
-                    "Failed to get manfile name from {:?}",
-                    manpage_path.display()
-                )
-            });
+    //                 let progress = format!(
+    //                     "{0:>1$} / {2} : {3}",
+    //                     index, max_digits, total, man_file_name,
+    //                 );
 
-        if show_progress && output_directory.is_some() {
-            let progress = format!(
-                "{0:>1$} / {2} : {3}",
-                index + 1,
-                max_digits,
-                total,
-                man_file_name,
-            );
+    //                 let stdout = std::io::stdout();
+    //                 let mut lock = stdout.lock();
+    //                 lock.write_all(format!("\r\x1b[K{}", progress).as_bytes())
+    //                     .expect("Failed to write to stdout");
+    //                 lock.flush().expect("Failed to flush stdout");
+    //                 index += 1;
+    //             }
+    //         });
+    //     }
+    // }
 
-            let stdout = std::io::stdout();
-            let mut lock = stdout.lock();
-            lock.write_all(format!("\r\x1b[K{}", progress).as_bytes())
-                .expect("Failed to write to stdout");
-            lock.flush().expect("Failed to flush stdout");
-        }
-
+    // let paths_iter = paths.par_iter().map_with(tx, |tx, manpage_path| {
+    let paths_iter = paths.par_iter().map(|manpage_path| {
+        // We know the lifetime will always be the same as another
+        // painting thread but how to not clone this?
+        // tx.send(manpage_path.to_owned()).unwrap();
         match parse_manpage_at_path(&manpage_path, output_directory.as_deref(), deroff_only) {
-            Ok(true) => successful_count += 1,
-            Ok(false) => {}
+            Ok(true) => 1,
+            Ok(false) => 0,
             Err(_) => {
                 tracing::info!("Cannot open {}", manpage_path.display());
+                0
             }
-        };
-    }
+        }
+    });
+    let successful_count: u64 = if show_progress {
+        paths_iter.progress().sum() // may not be accurate since it paints after
+    } else {
+        paths_iter.sum()
+    };
 
-    // TODO: use indicatif
     tracing::info!(
         "successfully parsed {} / {} pages",
         successful_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1318,75 +1318,17 @@ fn parse_manpage_at_path(
     }
 }
 
-/// Get the number of digits in num
-// fn num_digits(n: usize) -> usize {
-//     (1.max(n) as f32).log10() as usize + 1
-// }
-
-// #[test]
-// fn test_num_digits() {
-//     assert_eq!(num_digits(1000), 4);
-//     assert_eq!(num_digits(100), 3);
-//     assert_eq!(num_digits(33), 2);
-//     assert_eq!(num_digits(123456789012345), 15);
-//     assert_eq!(num_digits(0), 1);
-// }
-
 fn parse_and_output_man_pages(
     paths: &mut [PathBuf],
     output_directory: Option<PathBuf>,
     show_progress: bool,
     deroff_only: bool,
 ) {
-    paths.sort();
+    paths.par_sort_unstable();
 
-    // let max_digits = num_digits(paths.len());
-    // let (tx, rx) = mpsc::channel::<PathBuf>();
-
-    // // XXX: maybe we can do custom drawing logic or paint ourselves?
-    // if let Some(output_directory) = output_directory.as_ref() {
-    //     if show_progress {
-    //         println!(
-    //             "Parsing man pages and writing completions to {}",
-    //             output_directory.display()
-    //         );
-
-    //         // draw in another thread
-    //         thread::spawn(move || {
-    //             let mut index = 1;
-    //             while let Ok(manpage_path) = rx.recv() {
-    //                 // foo/bar/gcc.1.gz -> gcc.1.gz
-    //                 let man_file_name = manpage_path
-    //                     .file_name()
-    //                     .map(|fname| fname.to_string_lossy())
-    //                     .unwrap_or_else(|| {
-    //                         panic!(
-    //                             "Failed to get manfile name from {:?}",
-    //                             manpage_path.display()
-    //                         )
-    //                     });
-
-    //                 let progress = format!(
-    //                     "{0:>1$} / {2} : {3}",
-    //                     index, max_digits, total, man_file_name,
-    //                 );
-
-    //                 let stdout = std::io::stdout();
-    //                 let mut lock = stdout.lock();
-    //                 lock.write_all(format!("\r\x1b[K{}", progress).as_bytes())
-    //                     .expect("Failed to write to stdout");
-    //                 lock.flush().expect("Failed to flush stdout");
-    //                 index += 1;
-    //             }
-    //         });
-    //     }
-    // }
-
-    // let paths_iter = paths.par_iter().map_with(tx, |tx, manpage_path| {
     let paths_iter = paths.par_iter().map(|manpage_path| {
         // We know the lifetime will always be the same as another
         // painting thread but how to not clone this?
-        // tx.send(manpage_path.to_owned()).unwrap();
         match parse_manpage_at_path(&manpage_path, output_directory.as_deref(), deroff_only) {
             Ok(true) => 1,
             Ok(false) => 0,


### PR DESCRIPTION
Add progress bar with indicatif while parallelizing stuff.
It does not show what file it is processing so we may need to have a
custom painter.
Fix #50, #82

Debug ~20s
Release ~600ms

![output-opt](https://user-images.githubusercontent.com/4687791/119873591-46740280-bf57-11eb-8c4e-620617d13737.gif)

A simple implementation for this does not show custom progress, but if we want we need to do some custom painting, it can be done later.

While working on this I found logging missing some stuff.